### PR TITLE
 refactoring/problem-with-red-console

### DIFF
--- a/src/shared/ui/Button/Button.tsx
+++ b/src/shared/ui/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, ElementType } from 'react';
+import { ComponentPropsWithoutRef, ElementType, Ref, forwardRef } from 'react';
 
 import { clsx } from 'clsx';
 
@@ -10,27 +10,29 @@ type Props<T extends ElementType = 'button'> = {
   variant?: 'primary' | 'secondary';
 } & ComponentPropsWithoutRef<T>;
 
-export const Button = <T extends ElementType = 'button'>(props: Props<T>) => {
-  const {
-    as: Component = 'button',
-    children,
-    className,
-    disabled,
-    fullWidth,
-    variant = 'primary',
-    ...rest
-  } = props;
+export const Button = forwardRef(
+  <T extends ElementType = 'button'>(props: Props<T>, ref: Ref<any>) => {
+    const {
+      as: Component = 'button',
+      children,
+      className,
+      disabled,
+      fullWidth,
+      variant = 'primary',
+      ...rest
+    } = props;
 
-  const classNames = clsx(
-    s.button,
-    s[variant],
-    { [s.disabled]: disabled, [s.fullWidth]: fullWidth },
-    className
-  );
+    const classNames = clsx(
+      s.button,
+      s[variant],
+      { [s.disabled]: disabled, [s.fullWidth]: fullWidth },
+      className
+    );
 
-  return (
-    <Component className={classNames} {...rest}>
-      {children}
-    </Component>
-  );
-};
+    return (
+      <Component className={classNames} ref={ref} {...rest}>
+        {children}
+      </Component>
+    );
+  }
+);

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -21,7 +21,9 @@ export const Modal = (props: Props) => {
         <Overlay className={s.overlay} />
         <Content className={s.content}>
           <div className={s.header}>
-            <Title className={s.title}>{title}</Title>
+            <Title asChild className={s.title}>
+              {title}
+            </Title>
             <Close className={s.buttonClose}>
               <Cross height={25} width={25} />
             </Close>

--- a/src/widgets/decks/AddNewDeckModal/AddNewDeckModal.tsx
+++ b/src/widgets/decks/AddNewDeckModal/AddNewDeckModal.tsx
@@ -1,12 +1,12 @@
+import { Button } from '@/shared/ui/Button';
 import { Modal } from '@/shared/ui/Modal';
 
 import { NewDeckForm } from './NewDeckForm';
 import { NewDeckTitle } from './ui/NewDeckTitle';
-import { OpenNewDeckModalButton } from './ui/OpenNewDeckModalButton';
 
 export const AddNewDeckModal = () => {
   return (
-    <Modal title={<NewDeckTitle />} trigger={<OpenNewDeckModalButton />}>
+    <Modal title={<NewDeckTitle />} trigger={<Button>Add new Deck</Button>}>
       <NewDeckForm onSubmit={data => alert(data)} />
     </Modal>
   );


### PR DESCRIPTION
Знаю твою нелюбовь к any. Сейчас консоль белая, но есть Ref с any, можно было просто any. Пробовал вместо него HTMLButtonElement | HTMLAnchorElelment. Я так понял, тайпскрипт не согласен на эти или в блоке return. Т.к. компонент полиморфный, то имеем проблемы, что, например, в button нет href, а в "а" есть. Варианты решения:
-смириться с красной консолью 
-ветвить логику return в зависимости от пришедшего as
-сделать отдельный неполиморфный компонент ButtonForModal с форвардРефом
-оставить Ref<any>
-найти решение, как в среду видео из твиттера
